### PR TITLE
vram_write should be const

### DIFF
--- a/neslib.h
+++ b/neslib.h
@@ -215,7 +215,7 @@ void __fastcall__ vram_inc(unsigned char n);
 void __fastcall__ vram_read(unsigned char *dst, unsigned int size);
 
 // write a block to current address of vram, works only when rendering is turned off
-void __fastcall__ vram_write(unsigned char *src, unsigned int size);
+void __fastcall__ vram_write(const unsigned char *src, unsigned int size);
 
 
 // unpack RLE data to current address of vram, mostly used for nametables


### PR DESCRIPTION
Updating the method signature of `vram_write` so that the data pointer is const.