### PR TITLE
RLE decoder update

### DIFF
--- a/neslib.sinc
+++ b/neslib.sinc
@@ -562,6 +562,9 @@ _vram_unrle:
 
 	cmp <RLE_TAG
 	beq @2
+
+@is_literal:
+
 	sta PPU_DATA
 	sta <RLE_BYTE
 	bne @1
@@ -575,6 +578,13 @@ _vram_unrle:
 	inc <RLE_HIGH
 
 @21:
+
+	cmp#$01
+	bcs @is_run
+	lda <_RLE_TAG
+	bcc @is_literal
+
+@is_run:
 
 	tax
 	lda <RLE_BYTE


### PR DESCRIPTION
This fix proposed by Pinobatch (aka Tepples) aims to improve the decoder compatibility for nametables that have no unused tile, as in all 256 CHR tiles were used. Original thread: https://forums.nesdev.org/viewtopic.php?p=224941#p224941

The improvement consists of the following change: if a read byte is the tag but is followed by a "01" that means the tag won't act as a tag, but as data.

An updated encoder must be used to make full use of the new logic, but this updated version can also be used to fully load previously encoded RLE data that use fewer than 256 tiles.